### PR TITLE
Refactor: Separate UI and business logic in ResourceList

### DIFF
--- a/src/hooks/useResourceList.ts
+++ b/src/hooks/useResourceList.ts
@@ -1,0 +1,17 @@
+import { useQueries } from '@tanstack/react-query';
+import { getResourceDetails } from '../services/api';
+
+export const useResourceList = (resourceType: string, urls: string[]) => {
+    const resourceQueries = useQueries({
+        queries: urls.map((url) => ({
+            queryKey: [resourceType, url],
+            queryFn: () => getResourceDetails(url),
+            staleTime: 1000 * 60 * 60 * 24, // 1 hour
+        })),
+    });
+
+    const isLoading = resourceQueries.some((query) => query.isLoading);
+    const error = resourceQueries.some((query) => query.isError);
+
+    return { resourceQueries, isLoading, error };
+};


### PR DESCRIPTION
This PR moves the business logic for data fetching and state management out of the ResourceList component and into a new custom hook (useResourceList). This improves separation of concerns and makes the UI component cleaner and easier to test. Related to issue #3.