### PR TITLE
Centralize API configuration and error handling

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,17 +6,42 @@ const api = axios.create({
     baseURL: API_URL,
 });
 
+// Centralized error handler
+function handleApiError(error: unknown) {
+    if (axios.isAxiosError(error)) {
+        // You can customize this logic as needed
+        const message = error.response?.data?.message || error.message || 'API Error';
+        throw new Error(message);
+    }
+    throw error;
+}
+
 export const getFilms = async (): Promise<Film[]> => {
-    const response = await api.get('/films');
-    return response.data.results;
+    try {
+        const response = await api.get('/films');
+        return response.data.results;
+    } catch (error) {
+        handleApiError(error);
+        throw error; // for type safety
+    }
 };
 
 export const getFilmDetails = async (id: string): Promise<Film> => {
-    const response = await api.get(`/films/${id}`);
-    return response.data;
+    try {
+        const response = await api.get(`/films/${id}`);
+        return response.data;
+    } catch (error) {
+        handleApiError(error);
+        throw error;
+    }
 };
 
 export const getResourceDetails = async (url: string): Promise<Resource> => {
-    const response = await axios.get<Resource>(url);
-    return response.data;
+    try {
+        const response = await axios.get<Resource>(url);
+        return response.data;
+    } catch (error) {
+        handleApiError(error);
+        throw error;
+    }
 };


### PR DESCRIPTION
This PR centralizes API error handling in the api.ts service by introducing a handleApiError function and wrapping all API calls in try/catch blocks. This improves maintainability and ensures consistent error reporting. Related to issue #4.